### PR TITLE
HP-1783: rename proforma to payment request

### DIFF
--- a/src/forms/PrepareMailOutForm.php
+++ b/src/forms/PrepareMailOutForm.php
@@ -24,7 +24,7 @@ class PrepareMailOutForm extends Model implements MailOutFormInterface
     public const POSITIVE_BALANCE = 'positive';
     public const NEGATIVE_BALANCE = 'negative';
     public const INVOICE_TYPE = 'invoice';
-    public const PROFORMA_TYPE = 'proforma';
+    public const PROFORMA_TYPE = 'payment_request';
 
     public function rules()
     {

--- a/src/forms/PrepareMailOutForm.php
+++ b/src/forms/PrepareMailOutForm.php
@@ -24,7 +24,7 @@ class PrepareMailOutForm extends Model implements MailOutFormInterface
     public const POSITIVE_BALANCE = 'positive';
     public const NEGATIVE_BALANCE = 'negative';
     public const INVOICE_TYPE = 'invoice';
-    public const PROFORMA_TYPE = 'payment_request';
+    public const PAYMENT_REQUEST_TYPE = 'payment_request';
 
     public function rules()
     {
@@ -65,7 +65,7 @@ class PrepareMailOutForm extends Model implements MailOutFormInterface
     {
         return [
             self::INVOICE_TYPE => Yii::t('hipanel.document.mailout', 'Invoice'),
-            self::PROFORMA_TYPE => Yii::t('hipanel.document.mailout', 'Proforma'),
+            self::PAYMENT_REQUEST_TYPE => Yii::t('hipanel.document.mailout', 'Payment request'),
         ];
     }
 

--- a/src/messages/ru/hipanel.document.mailout.php
+++ b/src/messages/ru/hipanel.document.mailout.php
@@ -2,7 +2,7 @@
 
 return [
     'Invoice' => 'Инвойс',
-    'Proforma' => 'Проформа',
+    'Payment request' => 'Запрос на оплату',
     'Mail-out' => 'Рассылка документов',
     'Mail-out sent successfully' => 'Рассылка успешно отправлена',
     'Prepare mail-out' => 'Подготовка рассылки',

--- a/src/widgets/combo/FinancialDocumentTypeCombo.php
+++ b/src/widgets/combo/FinancialDocumentTypeCombo.php
@@ -9,7 +9,7 @@ use hipanel\models\Ref;
 class FinancialDocumentTypeCombo extends StaticCombo
 {
     final const INVOICE_TYPE = 'invoice';
-    final const PAYMENT_REQUEST_TYPE = 'proforma';
+    final const PAYMENT_REQUEST_TYPE = 'payment_request';
 
     public $hasId = true;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Changed terminology from 'Proforma' to 'Payment request' across the application for improved clarity.
  - Updated labels and options in forms and dropdowns to reflect the new terminology.

These changes aim to provide clearer communication and reduce confusion regarding document types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->