### PR TITLE
HP-2804: refactor document page test to use standard `page` object

### DIFF
--- a/tests/playwright/e2e/manager/document.spec.ts
+++ b/tests/playwright/e2e/manager/document.spec.ts
@@ -1,7 +1,7 @@
 import { test } from "@hipanel-core/fixtures";
 import { expect } from "@playwright/test";
 
-test("Test the Document page is work @hipanel-module-document @manager @document", async ({ managerPage }) => {
-  await managerPage.goto("/document/document/index");
-  await expect(managerPage.locator(".content-header > h1")).toContainText("Documents");
+test("Test the Document page is work @hipanel-module-document @manager @document", async ({ page }) => {
+  await page.goto("/document/document/index");
+  await expect(page.locator(".content-header > h1")).toContainText("Documents");
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end Document page test to use the generic page fixture for more consistent, stable test execution.

**Note:** This release contains only internal testing updates with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->