### PR TITLE
HQD-145: Replace file on Document detail page with reason + history

### DIFF
--- a/src/controllers/DocumentController.php
+++ b/src/controllers/DocumentController.php
@@ -22,6 +22,8 @@ use hipanel\modules\document\models\Document;
 use hipanel\modules\finance\actions\GenerateDocumentAction;
 use hiqdev\hiart\ResponseErrorException;
 use Yii;
+use yii\db\BaseActiveRecord;
+use yii\web\NotFoundHttpException;
 use yii\web\Response;
 
 /**
@@ -38,6 +40,7 @@ class DocumentController extends CrudController
                     'create,import,copy'    => 'document.create',
                     'update'                => 'document.update',
                     'delete'                => 'document.delete',
+                    'replace'               => 'document.replace',
                     '*'                     => 'document.read',
                 ],
             ],
@@ -68,7 +71,20 @@ class DocumentController extends CrudController
 
                     $action->getDataProvider()->query->details()->showDeleted();
                 },
-                'data' => fn() => $this->getAdditionalData(),
+                'data' => function () {
+                    $data = $this->getAdditionalData();
+                    $id = Yii::$app->request->get('id');
+                    $fileHistory = [];
+                    if ($id && Yii::$app->user->can('document.see-history')) {
+                        try {
+                            $fileHistory = Document::perform('get-file-history', ['id' => $id]);
+                        } catch (ResponseErrorException) {
+                            $fileHistory = [];
+                        }
+                    }
+                    $data['fileHistory'] = is_array($fileHistory) ? $fileHistory : [];
+                    return $data;
+                },
             ],
             'update' => [
                 'class' => SmartUpdateAction::class,
@@ -119,6 +135,38 @@ class DocumentController extends CrudController
 
             $action->getDataProvider()->query->details();
         };
+    }
+
+    public function actionReplace(int $id): Response|string
+    {
+        $models = Document::find()->where(['id' => $id])->details()->all();
+        $model = reset($models);
+        if (!$model) {
+            throw new NotFoundHttpException();
+        }
+        $model->scenario = Document::SCENARIO_REPLACE;
+
+        if (Yii::$app->request->isPost) {
+            if ($model->load(Yii::$app->request->post()) && $model->validate()) {
+                // Trigger FileBehavior to upload the file and populate file_id.
+                $model->trigger(BaseActiveRecord::EVENT_BEFORE_UPDATE);
+
+                try {
+                    Document::perform('replace-file', [
+                        'id'      => $model->id,
+                        'file_id' => $model->file_id,
+                        'reason'  => $model->reason,
+                    ]);
+                    Yii::$app->session->setFlash('success', Yii::t('hipanel:document', 'Document file was replaced'));
+
+                    return $this->redirect(['@document/view', 'id' => $model->id]);
+                } catch (ResponseErrorException $e) {
+                    Yii::$app->session->setFlash('error', $e->getMessage());
+                }
+            }
+        }
+
+        return $this->render('replace', ['model' => $model]);
     }
 
     public function actionArchive()

--- a/src/grid/DocumentGridView.php
+++ b/src/grid/DocumentGridView.php
@@ -123,7 +123,7 @@ class DocumentGridView extends BoxedGridView
                 'label' => Yii::t('hipanel:document', 'Related object'),
                 'format' => 'raw',
                 'value' => function ($model) {
-                    return DocumentRelationWidget::widget(['model' => $model->object]);
+                    return DocumentRelationWidget::widget(['model' => $model->isRelationPopulated('object') ? $model->object : null]);
                 },
             ],
             'status' => [

--- a/src/menus/DocumentActionsMenu.php
+++ b/src/menus/DocumentActionsMenu.php
@@ -51,6 +51,12 @@ class DocumentActionsMenu extends \hiqdev\yii2\menus\Menu
                 'url' => ['@document/update', 'id' => $this->model->id],
                 'visible' => Yii::$app->user->can('document.update') && $this->model->state !== 'deleted',
             ],
+            'replace' => [
+                'label' => Yii::t('hipanel:document', 'Replace'),
+                'icon' => 'fa-exchange',
+                'url' => ['@document/replace', 'id' => $this->model->id],
+                'visible' => Yii::$app->user->can('document.replace') && $this->model->state !== 'deleted',
+            ],
             'delete' => [
                 'label' => Yii::t('hipanel', 'Delete'),
                 'icon' => 'fa-trash',

--- a/src/models/Document.php
+++ b/src/models/Document.php
@@ -32,6 +32,9 @@ class Document extends \hipanel\base\Model
     const SCENARIO_CREATE = 'create';
     const SCENARIO_UPDATE = 'update';
     const SCENARIO_DELETE = 'delete';
+    const SCENARIO_REPLACE = 'replace';
+
+    public string $reason = '';
 
     /**
      * {@inheritdoc}
@@ -48,7 +51,7 @@ class Document extends \hipanel\base\Model
                 'class' => FileBehavior::class,
                 'attribute' => 'attachment',
                 'targetAttribute' => 'file_id',
-                'scenarios' => ['create'],
+                'scenarios' => ['create', 'replace'],
             ],
             [
                 'class' => JsonBehavior::class,
@@ -92,7 +95,10 @@ class Document extends \hipanel\base\Model
                 'enableClientValidation' => false,
                 'when' => fn(): bool => Yii::$app->user->can('document.update'),
             ],
-            [['id'], 'required', 'on' => ['update', 'delete']],
+            [['id'], 'required', 'on' => ['update', 'delete', 'replace']],
+            [['attachment'], 'safe', 'on' => ['replace']],
+            [['reason'], 'required', 'on' => 'replace'],
+            [['reason'], 'string', 'on' => 'replace'],
             [['data'], JsonValidator::class],
             [['templateid', 'template_name'], 'string'],
         ];
@@ -104,13 +110,14 @@ class Document extends \hipanel\base\Model
     public function attributeLabels()
     {
         return $this->mergeAttributeLabels([
-            'type_id' => Yii::t('hipanel', 'Type'),
-            'attachment' => Yii::t('hipanel:document', 'File'),
+            'type_id'     => Yii::t('hipanel', 'Type'),
+            'attachment'  => Yii::t('hipanel:document', 'File'),
             'status_types' => Yii::t('hipanel:document', 'Statuses'),
-            'sender_id' => Yii::t('hipanel:document', 'Sender'),
+            'sender_id'   => Yii::t('hipanel:document', 'Sender'),
             'receiver_id' => Yii::t('hipanel:document', 'Receiver'),
             'requisite_id' => Yii::t('hipanel:finance', 'Requisite'),
-            'requisite' => Yii::t('hipanel:finance', 'Requisite'),
+            'requisite'   => Yii::t('hipanel:finance', 'Requisite'),
+            'reason'      => Yii::t('hipanel:document', 'Reason for replacement'),
         ]);
     }
 

--- a/src/views/document/replace.php
+++ b/src/views/document/replace.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @var \yii\web\View $this
+ * @var \hipanel\modules\document\models\Document $model
+ */
+
+use hipanel\widgets\Box;
+use hipanel\widgets\FileRender;
+use yii\helpers\Html;
+use yii\helpers\Url;
+use yii\widgets\ActiveForm;
+
+$this->title = Yii::t('hipanel:document', 'Replace document file');
+$this->params['subtitle'] = Html::encode($model->getDisplayTitle());
+$this->params['breadcrumbs'][] = ['label' => Yii::t('hipanel:document', 'Documents'), 'url' => ['index']];
+$this->params['breadcrumbs'][] = ['label' => $model->getDisplayTitle(), 'url' => ['@document/view', 'id' => $model->id]];
+$this->params['breadcrumbs'][] = Yii::t('hipanel:document', 'Replace');
+
+?>
+<div class="row">
+    <div class="col-md-3">
+        <?php Box::begin(['options' => ['class' => 'box-solid'], 'title' => Yii::t('hipanel:document', 'Current file')]) ?>
+        <div class="text-center">
+            <?= FileRender::widget([
+                'file' => $model->file,
+                'thumbWidth' => 200,
+                'thumbHeight' => 200,
+                'lightboxLinkOptions' => [
+                    'data-lightbox' => 'files-' . $model->file->id,
+                ],
+            ]) ?>
+        </div>
+        <p class="text-center text-muted small"><?= Html::encode($model->filename) ?></p>
+        <?php Box::end() ?>
+    </div>
+
+    <div class="col-md-6">
+        <?php Box::begin(['title' => Yii::t('hipanel:document', 'Replace file')]) ?>
+        <?php $form = ActiveForm::begin([
+            'id' => 'document-replace-form',
+            'enableAjaxValidation' => true,
+            'validationUrl' => Url::toRoute([
+                'validate-single-form',
+                'scenario' => $model->scenario,
+            ]),
+            'options' => ['enctype' => 'multipart/form-data'],
+        ]) ?>
+
+        <?= Html::activeHiddenInput($model, 'id') ?>
+
+        <?= $form->field($model, 'attachment')->fileInput(['required' => true]) ?>
+
+        <?= $form->field($model, 'reason')->textarea([
+            'rows' => 4,
+            'required' => true,
+            'placeholder' => Yii::t('hipanel:document', 'Describe why this file is being replaced'),
+        ]) ?>
+
+        <?= Html::submitButton(Yii::t('hipanel:document', 'Replace'), ['class' => 'btn btn-warning']) ?>
+        &nbsp;
+        <?= Html::a(Yii::t('hipanel', 'Cancel'), ['@document/view', 'id' => $model->id], ['class' => 'btn btn-default']) ?>
+
+        <?php $form->end() ?>
+        <?php Box::end() ?>
+    </div>
+</div>

--- a/src/views/document/view.php
+++ b/src/views/document/view.php
@@ -96,7 +96,7 @@ $this->params['breadcrumbs'][] = $this->title;
                         <td><?= Html::encode($entry['reason']) ?></td>
                         <td><?= Html::a(
                             Html::tag('i', '', ['class' => 'fa fa-download']) . ' ' . Yii::t('hipanel:document', 'Download'),
-                            ['/file/download', 'id' => $entry['file_id']],
+                            ['/file/get', 'id' => $entry['file_id']],
                             ['class' => 'btn btn-xs btn-default']
                         ) ?></td>
                     </tr>

--- a/src/views/document/view.php
+++ b/src/views/document/view.php
@@ -1,13 +1,16 @@
 <?php
 
 /**
- * @var \hipanel\modules\document\models\Document
+ * @var \yii\web\View $this
+ * @var \hipanel\modules\document\models\Document $model
  * @var \hipanel\modules\document\models\Document[] $models
  * @var array $types
  * @var array $states
+ * @var array $fileHistory
  */
 use hipanel\modules\document\grid\DocumentGridView;
 use hipanel\modules\document\menus\DocumentDetailMenu;
+use hipanel\widgets\AuditButton;
 use hipanel\widgets\Box;
 use yii\helpers\Html;
 
@@ -41,6 +44,7 @@ $this->params['breadcrumbs'][] = $this->title;
         </p>
         <div class="profile-usermenu">
             <?= DocumentDetailMenu::widget(['model' => $model]) ?>
+            <?= AuditButton::widget(['model' => $model, 'linkOptions' => ['class' => 'list-group-item']]) ?>
         </div>
         <?php Box::end() ?>
     </div>
@@ -65,5 +69,42 @@ $this->params['breadcrumbs'][] = $this->title;
         <?php $box->endBody() ?>
         <?php $box->end() ?>
 
+        <?php if (Yii::$app->user->can('document.see-history') && !empty($fileHistory)): ?>
+            <?php $box = Box::begin([
+                'renderBody' => false,
+                'title' => Yii::t('hipanel:document', 'File replacement history'),
+            ]) ?>
+            <?php $box->beginBody() ?>
+            <table class="table table-condensed table-hover">
+                <thead>
+                    <tr>
+                        <th><?= Yii::t('hipanel:document', 'File') ?></th>
+                        <th><?= Yii::t('hipanel:document', 'Size') ?></th>
+                        <th><?= Yii::t('hipanel:document', 'Valid till') ?></th>
+                        <th><?= Yii::t('hipanel:document', 'Replaced by') ?></th>
+                        <th><?= Yii::t('hipanel:document', 'Reason') ?></th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($fileHistory as $entry): ?>
+                    <tr>
+                        <td><?= Html::encode($entry['filename']) ?></td>
+                        <td><?= Yii::$app->formatter->asShortSize($entry['size']) ?></td>
+                        <td><?= Yii::$app->formatter->asDatetime($entry['replaced_at']) ?></td>
+                        <td><?= Html::encode($entry['client']) ?></td>
+                        <td><?= Html::encode($entry['reason']) ?></td>
+                        <td><?= Html::a(
+                            Html::tag('i', '', ['class' => 'fa fa-download']) . ' ' . Yii::t('hipanel:document', 'Download'),
+                            ['/file/download', 'id' => $entry['file_id']],
+                            ['class' => 'btn btn-xs btn-default']
+                        ) ?></td>
+                    </tr>
+                    <?php endforeach ?>
+                </tbody>
+            </table>
+            <?php $box->endBody() ?>
+            <?php $box->end() ?>
+        <?php endif ?>
     </div>
 </div>

--- a/tests/playwright/e2e/client/document.spec.ts
+++ b/tests/playwright/e2e/client/document.spec.ts
@@ -1,0 +1,51 @@
+import { test } from "@hipanel-core/fixtures";
+import { expect } from "@playwright/test";
+import DocumentView from "@hipanel-module-document/page/document/DocumentView";
+
+async function gotoFirstDocumentOrSkip(page, view: DocumentView): Promise<boolean> {
+  await page.goto("/document/document/index");
+  const firstLink = page.locator('a[href*="/document/document/view"]').first();
+  if (await firstLink.count() === 0) {
+    return false;
+  }
+  await firstLink.click();
+  await page.waitForURL("**/document/document/view**");
+  return true;
+}
+
+test("Client cannot see Replace button on document detail page @hipanel-module-document @client @document", async ({ page }) => {
+  const view = new DocumentView(page);
+  if (!await gotoFirstDocumentOrSkip(page, view)) {
+    test.skip(true, "No documents visible to this client");
+    return;
+  }
+  await expect(view.replaceButton()).not.toBeVisible();
+});
+
+test("Client cannot see File replacement history section @hipanel-module-document @client @document", async ({ page }) => {
+  const view = new DocumentView(page);
+  if (!await gotoFirstDocumentOrSkip(page, view)) {
+    test.skip(true, "No documents visible to this client");
+    return;
+  }
+  await view.assertHistoryNotVisible();
+});
+
+test("Client is redirected when accessing replace URL directly @hipanel-module-document @client @document", async ({ page }) => {
+  await page.goto("/document/document/index");
+  const firstLink = page.locator('a[href*="/document/document/view"]').first();
+  if (await firstLink.count() === 0) {
+    test.skip(true, "No documents visible to this client");
+    return;
+  }
+
+  const href = await firstLink.getAttribute("href");
+  const docId = href?.match(/id=(\d+)/)?.[1];
+  if (!docId) {
+    test.skip(true, "Could not extract document ID");
+    return;
+  }
+
+  await page.goto(`/document/document/replace?id=${docId}`);
+  await expect(page).not.toHaveTitle("Replace document file");
+});

--- a/tests/playwright/e2e/client/document.spec.ts
+++ b/tests/playwright/e2e/client/document.spec.ts
@@ -2,32 +2,13 @@ import { test } from "@hipanel-core/fixtures";
 import { expect } from "@playwright/test";
 import DocumentView from "@hipanel-module-document/page/document/DocumentView";
 
-async function gotoFirstDocumentOrSkip(page, view: DocumentView): Promise<boolean> {
-  await page.goto("/document/document/index");
-  const firstLink = page.locator('a[href*="/document/document/view"]').first();
-  if (await firstLink.count() === 0) {
-    return false;
-  }
-  await firstLink.click();
-  await page.waitForURL("**/document/document/view**");
-  return true;
-}
-
-test("Client cannot see Replace button on document detail page @hipanel-module-document @client @document", async ({ page }) => {
+test("Client cannot see Replace button or File replacement history section @hipanel-module-document @client @document", async ({ page }) => {
   const view = new DocumentView(page);
-  if (!await gotoFirstDocumentOrSkip(page, view)) {
+  if (!await view.gotoFirstDocumentOrSkip()) {
     test.skip(true, "No documents visible to this client");
     return;
   }
   await expect(view.replaceButton()).not.toBeVisible();
-});
-
-test("Client cannot see File replacement history section @hipanel-module-document @client @document", async ({ page }) => {
-  const view = new DocumentView(page);
-  if (!await gotoFirstDocumentOrSkip(page, view)) {
-    test.skip(true, "No documents visible to this client");
-    return;
-  }
   await view.assertHistoryNotVisible();
 });
 

--- a/tests/playwright/e2e/manager/document.spec.ts
+++ b/tests/playwright/e2e/manager/document.spec.ts
@@ -15,35 +15,18 @@ test("Document index page is accessible @hipanel-module-document @manager @docum
   await expect(page.locator(".content-header > h1")).toContainText("Documents");
 });
 
-test("Replace button is visible on detail page for manager @hipanel-module-document @manager @document", async ({ page }) => {
-  const view = new DocumentView(page);
-  await view.gotoFirstDocument();
-  await expect(view.replaceButton()).toBeVisible();
-});
-
-test("Replace form shows current file, file picker, reason field and Cancel @hipanel-module-document @manager @document", async ({ page }) => {
+test("Replace button is visible, form structure is correct, and submission without reason is rejected @hipanel-module-document @manager @document", async ({ page }) => {
   const view = new DocumentView(page);
   const form = new DocumentReplaceForm(page);
 
   await view.gotoFirstDocument();
-  const viewUrl = page.url();
 
+  await expect(view.replaceButton()).toBeVisible();
   await view.clickReplace();
   await form.assertOnPage();
   await expect(page.locator("#document-attachment")).toBeAttached();
   await expect(page.locator("#document-reason")).toBeVisible();
   await expect(page.locator('a.btn-default:has-text("Cancel")')).toHaveAttribute("href", new RegExp("/document/document/view"));
-
-  await form.cancel();
-  await expect(page).toHaveURL(viewUrl);
-});
-
-test("Replace form rejects submission without a reason @hipanel-module-document @manager @document", async ({ page }) => {
-  const view = new DocumentView(page);
-  const form = new DocumentReplaceForm(page);
-
-  await view.gotoFirstDocument();
-  await view.clickReplace();
 
   await form.uploadFile(TEST_PDF);
   await form.submit();
@@ -69,7 +52,7 @@ test("History section is absent on a document with no prior replacements @hipane
   }
 });
 
-test("Replacing a file creates a history entry with correct data @hipanel-module-document @manager @document", async ({ page }) => {
+test("Replacing a file creates a history entry with correct data, columns and download link @hipanel-module-document @manager @document", async ({ page }) => {
   const view = new DocumentView(page);
   const form = new DocumentReplaceForm(page);
 
@@ -88,18 +71,6 @@ test("Replacing a file creates a history entry with correct data @hipanel-module
   await form.assertSuccessAndRedirect(viewUrl);
   await view.assertHistoryVisible();
   await view.assertHistoryRow(0, { filename: previousFilename, reason: REPLACE_REASON });
-});
-
-test("History section shows all required columns and a working Download link @hipanel-module-document @manager @document", async ({ page }) => {
-  const view = new DocumentView(page);
-
-  await view.gotoFirstDocument();
-
-  if (!await view.historyBox().isVisible()) {
-    test.skip(true, "No history rows on this document; run after the replacement test");
-    return;
-  }
-
   await view.assertHistoryColumns();
   await view.assertDownloadLinkVisible(0);
 });

--- a/tests/playwright/e2e/manager/document.spec.ts
+++ b/tests/playwright/e2e/manager/document.spec.ts
@@ -1,7 +1,105 @@
 import { test } from "@hipanel-core/fixtures";
 import { expect } from "@playwright/test";
+import { fileURLToPath } from "url";
+import path from "path";
+import DocumentView from "@hipanel-module-document/page/document/DocumentView";
+import DocumentReplaceForm from "@hipanel-module-document/page/document/DocumentReplaceForm";
 
-test("Test the Document page is work @hipanel-module-document @manager @document", async ({ page }) => {
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const TEST_PDF = path.join(__dirname, "../../fixtures/test.pdf");
+const REPLACE_REASON = "E2E test replacement reason";
+
+test("Document index page is accessible @hipanel-module-document @manager @document", async ({ page }) => {
   await page.goto("/document/document/index");
   await expect(page.locator(".content-header > h1")).toContainText("Documents");
+});
+
+test("Replace button is visible on detail page for manager @hipanel-module-document @manager @document", async ({ page }) => {
+  const view = new DocumentView(page);
+  await view.gotoFirstDocument();
+  await expect(view.replaceButton()).toBeVisible();
+});
+
+test("Replace form shows current file, file picker, reason field and Cancel @hipanel-module-document @manager @document", async ({ page }) => {
+  const view = new DocumentView(page);
+  const form = new DocumentReplaceForm(page);
+
+  await view.gotoFirstDocument();
+  const viewUrl = page.url();
+
+  await view.clickReplace();
+  await form.assertOnPage();
+  await expect(page.locator("#document-attachment")).toBeAttached();
+  await expect(page.locator("#document-reason")).toBeVisible();
+  await expect(page.locator('a.btn-default:has-text("Cancel")')).toHaveAttribute("href", new RegExp("/document/document/view"));
+
+  await form.cancel();
+  await expect(page).toHaveURL(viewUrl);
+});
+
+test("Replace form rejects submission without a reason @hipanel-module-document @manager @document", async ({ page }) => {
+  const view = new DocumentView(page);
+  const form = new DocumentReplaceForm(page);
+
+  await view.gotoFirstDocument();
+  await view.clickReplace();
+
+  await form.uploadFile(TEST_PDF);
+  await form.submit();
+  await form.assertReasonRequired();
+});
+
+test("History section is absent on a document with no prior replacements @hipanel-module-document @manager @document", async ({ page }) => {
+  const view = new DocumentView(page);
+
+  await page.goto("/document/document/index");
+  const links = page.locator('a[href*="/document/document/view"]');
+  expect(await links.count()).toBeGreaterThan(0);
+
+  for (let i = 0; i < Math.min(await links.count(), 5); i++) {
+    await page.goto("/document/document/index");
+    await links.nth(i).click();
+    await page.waitForURL("**/document/document/view**");
+
+    if (!await view.historyBox().isVisible()) {
+      await view.assertHistoryNotVisible();
+      return;
+    }
+  }
+});
+
+test("Replacing a file creates a history entry with correct data @hipanel-module-document @manager @document", async ({ page }) => {
+  const view = new DocumentView(page);
+  const form = new DocumentReplaceForm(page);
+
+  await view.gotoFirstDocument();
+  const viewUrl = page.url();
+
+  await view.clickReplace();
+  await form.assertOnPage();
+
+  const previousFilename = await form.currentFilename();
+
+  await form.uploadFile(TEST_PDF);
+  await form.fillReason(REPLACE_REASON);
+  await form.submit();
+
+  await form.assertSuccessAndRedirect(viewUrl);
+  await view.assertHistoryVisible();
+  await view.assertHistoryRow(0, { filename: previousFilename, reason: REPLACE_REASON });
+});
+
+test("History section shows all required columns and a working Download link @hipanel-module-document @manager @document", async ({ page }) => {
+  const view = new DocumentView(page);
+
+  await view.gotoFirstDocument();
+
+  if (!await view.historyBox().isVisible()) {
+    test.skip(true, "No history rows on this document; run after the replacement test");
+    return;
+  }
+
+  await view.assertHistoryColumns();
+  await view.assertDownloadLinkVisible(0);
 });

--- a/tests/playwright/fixtures/test.pdf
+++ b/tests/playwright/fixtures/test.pdf
@@ -1,0 +1,14 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R>>endobj
+xref
+0 4
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+trailer<</Size 4/Root 1 0 R>>
+startxref
+183
+%%EOF

--- a/tests/playwright/page/document/DocumentReplaceForm.ts
+++ b/tests/playwright/page/document/DocumentReplaceForm.ts
@@ -1,3 +1,5 @@
+import fs from "fs";
+import path from "path";
 import { expect, Page } from "@playwright/test";
 import { Alert } from "@hipanel-core/shared/ui/components";
 
@@ -14,7 +16,15 @@ export default class DocumentReplaceForm {
   }
 
   async uploadFile(filePath: string): Promise<void> {
-    await this.page.locator("#document-attachment").setInputFiles(filePath);
+    const buffer = Buffer.concat([
+      fs.readFileSync(filePath),
+      Buffer.from(`\n% unique:${Date.now()}\n`),
+    ]);
+    await this.page.locator("#document-attachment").setInputFiles({
+      name: path.basename(filePath),
+      mimeType: "application/pdf",
+      buffer,
+    });
   }
 
   async fillReason(reason: string): Promise<void> {
@@ -30,8 +40,7 @@ export default class DocumentReplaceForm {
   }
 
   async assertReasonRequired(): Promise<void> {
-    await expect(this.page.locator(".field-document-reason")).toHaveClass(/has-error/);
-    await expect(this.page.locator(".field-document-reason .help-block")).toContainText("cannot be blank");
+    await expect(this.page.locator("#document-reason:invalid")).toBeAttached();
     await expect(this.page).toHaveURL(/\/document\/replace/);
   }
 

--- a/tests/playwright/page/document/DocumentReplaceForm.ts
+++ b/tests/playwright/page/document/DocumentReplaceForm.ts
@@ -1,0 +1,42 @@
+import { expect, Page } from "@playwright/test";
+import { Alert } from "@hipanel-core/shared/ui/components";
+
+export default class DocumentReplaceForm {
+  constructor(private readonly page: Page) {}
+
+  async assertOnPage(): Promise<void> {
+    await expect(this.page).toHaveTitle("Replace document file");
+    await expect(this.page.locator(".box-title:has-text('Current file')")).toBeVisible();
+  }
+
+  async currentFilename(): Promise<string> {
+    return (await this.page.locator("p.text-center.text-muted.small").textContent())?.trim() ?? "";
+  }
+
+  async uploadFile(filePath: string): Promise<void> {
+    await this.page.locator("#document-attachment").setInputFiles(filePath);
+  }
+
+  async fillReason(reason: string): Promise<void> {
+    await this.page.locator("#document-reason").fill(reason);
+  }
+
+  async submit(): Promise<void> {
+    await this.page.locator("button.btn-warning").click();
+  }
+
+  async cancel(): Promise<void> {
+    await this.page.locator('a.btn-default:has-text("Cancel")').click();
+  }
+
+  async assertReasonRequired(): Promise<void> {
+    await expect(this.page.locator(".field-document-reason")).toHaveClass(/has-error/);
+    await expect(this.page.locator(".field-document-reason .help-block")).toContainText("cannot be blank");
+    await expect(this.page).toHaveURL(/\/document\/replace/);
+  }
+
+  async assertSuccessAndRedirect(viewUrl: string): Promise<void> {
+    await expect(this.page).toHaveURL(viewUrl);
+    await Alert.on(this.page).hasText("Document file was replaced");
+  }
+}

--- a/tests/playwright/page/document/DocumentView.ts
+++ b/tests/playwright/page/document/DocumentView.ts
@@ -73,7 +73,7 @@ export default class DocumentView {
   async assertDownloadLinkVisible(nth: number = 0): Promise<void> {
     const link = this.historyTable().locator("tbody tr").nth(nth).locator('a:has-text("Download")');
     await expect(link).toBeVisible();
-    await expect(link).toHaveAttribute("href", /\/file\/download/);
+    await expect(link).toHaveAttribute("href", /\/file\/get/);
   }
 
   async currentFilename(): Promise<string> {

--- a/tests/playwright/page/document/DocumentView.ts
+++ b/tests/playwright/page/document/DocumentView.ts
@@ -5,7 +5,7 @@ export default class DocumentView {
   private readonly historyBoxLocator: Locator;
 
   constructor(private readonly page: Page) {
-    this.detailMenu = page.locator(".profile-usermenu .list-group");
+    this.detailMenu = page.locator(".profile-usermenu .nav");
     this.historyBoxLocator = page.locator('.box:has(.box-title:has-text("File replacement history"))');
   }
 
@@ -13,6 +13,17 @@ export default class DocumentView {
     await this.page.goto("/document/document/index");
     await this.page.locator('a[href*="/document/document/view"]').first().click();
     await this.page.waitForURL("**/document/document/view**");
+  }
+
+  async gotoFirstDocumentOrSkip(): Promise<boolean> {
+    await this.page.goto("/document/document/index");
+    const firstLink = this.page.locator('a[href*="/document/document/view"]').first();
+    if (await firstLink.count() === 0) {
+      return false;
+    }
+    await firstLink.click();
+    await this.page.waitForURL("**/document/document/view**");
+    return true;
   }
 
   replaceButton(): Locator {

--- a/tests/playwright/page/document/DocumentView.ts
+++ b/tests/playwright/page/document/DocumentView.ts
@@ -1,0 +1,71 @@
+import { expect, Locator, Page } from "@playwright/test";
+
+export default class DocumentView {
+  private readonly detailMenu: Locator;
+  private readonly historyBoxLocator: Locator;
+
+  constructor(private readonly page: Page) {
+    this.detailMenu = page.locator(".profile-usermenu .list-group");
+    this.historyBoxLocator = page.locator('.box:has(.box-title:has-text("File replacement history"))');
+  }
+
+  async gotoFirstDocument(): Promise<void> {
+    await this.page.goto("/document/document/index");
+    await this.page.locator('a[href*="/document/document/view"]').first().click();
+    await this.page.waitForURL("**/document/document/view**");
+  }
+
+  replaceButton(): Locator {
+    return this.detailMenu.locator('a:has-text("Replace")');
+  }
+
+  async clickReplace(): Promise<void> {
+    await this.replaceButton().click();
+  }
+
+  historyBox(): Locator {
+    return this.historyBoxLocator;
+  }
+
+  historyTable(): Locator {
+    return this.historyBoxLocator.locator("table");
+  }
+
+  async assertHistoryVisible(): Promise<void> {
+    await expect(this.historyBoxLocator).toBeVisible();
+  }
+
+  async assertHistoryNotVisible(): Promise<void> {
+    await expect(this.historyBoxLocator).not.toBeVisible();
+  }
+
+  async assertHistoryColumns(): Promise<void> {
+    const thead = this.historyTable().locator("thead th");
+    await expect(thead.nth(0)).toContainText("File");
+    await expect(thead.nth(1)).toContainText("Size");
+    await expect(thead.nth(2)).toContainText("Valid till");
+    await expect(thead.nth(3)).toContainText("Replaced by");
+    await expect(thead.nth(4)).toContainText("Reason");
+  }
+
+  async assertHistoryRow(nth: number, data: { filename?: string; reason?: string }): Promise<void> {
+    const row = this.historyTable().locator("tbody tr").nth(nth);
+    await expect(row).toBeVisible();
+    if (data.filename) {
+      await expect(row.locator("td").nth(0)).toContainText(data.filename);
+    }
+    if (data.reason) {
+      await expect(row.locator("td").nth(4)).toContainText(data.reason);
+    }
+  }
+
+  async assertDownloadLinkVisible(nth: number = 0): Promise<void> {
+    const link = this.historyTable().locator("tbody tr").nth(nth).locator('a:has-text("Download")');
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", /\/file\/download/);
+  }
+
+  async currentFilename(): Promise<string> {
+    return (await this.page.locator("p.text-center.text-muted.small").textContent())?.trim() ?? "";
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document file replacement UI with required reason, confirmation, and redirect flow
  * "Replace" action in document menu for authorized users; replacement endpoint to submit new files
  * Replacement history panel showing past replacements, metadata, and download links for authorized users
* **Improvements**
  * Detail view shows audit controls; list rendering optimized for unloaded relations
  * History data is conditionally shown based on permission and safely defaults when unavailable
* **Tests**
  * Playwright E2E tests and page objects covering replace flows, validations, history visibility, and permissions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiqdev/hipanel-module-document/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->